### PR TITLE
Declare created_at field on EsvDataSourceService

### DIFF
--- a/micro-api/src/services/esv-data-source/esv-data-source.service.ts
+++ b/micro-api/src/services/esv-data-source/esv-data-source.service.ts
@@ -33,6 +33,9 @@ export class EsvDataSourceService extends juggler.DataSource {
         id: {
           type: 'keyword',
         },
+        created_at: {
+          type: 'date',
+        },
         owner_id: {
           type: 'keyword',
         },


### PR DESCRIPTION
Hi! 👋 

From what I've experienced running the project locally, the request to get existing messages of a channel fails when there are no messages in ElasticSearch because of this.

Let me know if I got something wrong or should do something differently.